### PR TITLE
Added convergence and step size optimizations, bug tracker document, and other small optimizations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vs/
 bin/
 build/
-docs/
 ManipulatorCollisionAvoidance.vcxproj.user

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -14,6 +14,19 @@
 - Link safety distance so it only is changed in one place.
 - Sparse matrix multiplication for jacobians.
 - Review power of DualQuat.
+- Motion Planner loop takes ~50-250 us.
+    - SetJointAngles() takes ~40 us.
+        - 3 us for kinematics, 37 us for generateContacts().
+            - Majority of time spent in physx specific functions, not much room for optimization here.
+                - Maybe I could use aggregates to better optimize broad phase as there is little difference between no contacts and contacts in time.
+    - ScLERP takes ~10 us.
+    - CollisionDisplacement takes ~0-200 us ().
+        - LCP generation takes ~90% of this time.
+            - Majority of time in generation split evenly between pseudoInv and assignment to M.
+            - Suggest I rework to accomplish three things:
+                1. Store column specific information as it is computed multiple times.
+                2. Traverse the matrix for assignment in column-major order.
+                3. Write my own pseudo-inverse function, or use QR/SVD decomposition, or some other least-squares solution.
 
 ## New Features
 - Add gripper bodies and joints.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,0 +1,29 @@
+# Issues and Feature Ideas
+
+## Issues
+- Divergence when EE is close to goal.
+    - Idea: Small tau + close to goal = small value = underflow?
+- Last box appears to sometimes not have collision.
+- Contact points switch between links and obstacles... how to make consistant?
+
+## Review/Refactor/Optimize
+- B Matrix.
+- Dynamic polymorphism for shapes rather than function overloading.
+- Review structure and program flow.
+    - Pay special attention to getters and whether they return references.
+- Link safety distance so it only is changed in one place.
+- Sparse matrix multiplication for jacobians.
+- Review power of DualQuat.
+
+## New Features
+- Add gripper bodies and joints.
+    - Do I need to switch to a KinematicTree?
+- Add metric to determine if the grasp is possible.
+    - Distance + Normals.
+    - Take the normals from the object to both of the grippers, and if they lie within a certain cone, it is a good grasp.
+
+## LCP Solver
+- Look into IGS solver.
+- Switch to OOP.
+- Add proper tests.
+- Can choose pivots with collision information. Closest points tell us next best pivot?

--- a/include/Kinematics.h
+++ b/include/Kinematics.h
@@ -23,6 +23,4 @@ namespace Kinematics
     /*FILL THIS IN LATER*/
     Eigen::MatrixXd BMatrix(const Eigen::MatrixXd& J, const Eigen::Matrix4d& pose);
 
-    // Override Eigen's implementation of Quaternion -> AxisAngle.
-    // Need to do this to fix degenerate 0 angle case (representation singularity) with axis [0, 0, 1], not [1, 0, 0].
 }

--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -20,7 +20,12 @@ private:
 	double m_tau = 0.01;
 	double m_timeStep = 0.01;
 	double m_safetyDistance = 0.02;
-	double m_maxDisplacementChangeAllowed = 0.001;
+	double m_maxScLERPDisplacementChange = 0.005;
+	double m_maxCollisionDisplacementChange = 0.001;
+	double m_maxTotalDisplacementChange = 0.01;
+	bool m_tauIsMax = false;
+	double m_positionTolerance = 0.02;
+	double m_quatTolerance = 0.02;
 
 	// Manipulator information.
 	RigidBody m_endFrame;
@@ -37,7 +42,7 @@ public:
 	MotionPlanner(SpatialManipulator* pSpatialManipulator, const Eigen::Matrix4d& goalTransform);
 
 	// Get the change in joint displacements before correction using ScLERP.
-	Eigen::VectorXd getJointDisplacementChange() const;
+	Eigen::VectorXd getJointDisplacementChange();
 	
 	// Get the null space term.
 	double getNullSpaceTerm() const;

--- a/src/ContactReportCallback.cpp
+++ b/src/ContactReportCallback.cpp
@@ -2,9 +2,7 @@
 #include "PxPhysicsAPI.h"
 #include <vector>
 #include "ContactPoint.h"
-#include <iostream>
 #include <Eigen/Dense>
-#include <iostream>
 
 void ContactReportCallback::onConstraintBreak(physx::PxConstraintInfo* constraints, physx::PxU32 count)
 {

--- a/src/FrankaPanda.cpp
+++ b/src/FrankaPanda.cpp
@@ -126,7 +126,12 @@ void FrankaPanda::initRigidBodyChain()
 	RigidBody link7(joint7, transform7);
 
 	// Tip frame.
-	Eigen::Matrix4d transformTip = transform7;
+	Eigen::Matrix4d transformTip = Eigen::Matrix4d{
+		{1,  0,  0, 0.0880},
+		{0, -1,  0,      0},
+		{0,  0, -1,  0.926},
+		{0,  0,  0,      1}
+	};
 	Eigen::Vector3d localAxisTip(0, 0, 0);
 	Eigen::Vector3d spatialAxisTip = transformTip.block(0, 0, 3, 3) * localAxisTip;
 	Joint jointTip(Joint::FIXED, spatialAxisTip, transformTip.block(0, 3, 3, 1));
@@ -197,8 +202,12 @@ void FrankaPanda::initRigidBodyChain()
 		Sphere link6_sphere0(Eigen::Vector3d(0.088/2, 0.06/2, 0), Eigen::Vector3d(0, 0, 0), 0.06, "link6_sphere0");
 		link6.addCollider(link6_sphere0);
 
-		Box link7_box0(Eigen::Vector3d(0, 0, 0.1070 - (0.02/2)), Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0.05, 0.05, 0.02), "link7_box0");
+		Box link7_box0(Eigen::Vector3d(0, 0, 0.1070 - (0.02)), Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0.05, 0.05, 0.02), "link7_box0");
 		link7.addCollider(link7_box0);
+
+		Sphere linkTip_sphere0(Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0, 0, 0), 0.01, "linkTip_sphere0");
+		linkTip.addCollider(linkTip_sphere0);
+
 	}
 
 

--- a/src/FrankaPanda.cpp
+++ b/src/FrankaPanda.cpp
@@ -126,14 +126,6 @@ void FrankaPanda::initRigidBodyChain()
 	RigidBody link7(joint7, transform7);
 
 	// Tip frame.
-	/*
-	Eigen::Matrix4d transformTip = Eigen::Matrix4d{
-		{1,  0,  0, 0.088},
-		{0, -1,  0,     0},
-		{0,  0, -1, 0.926},
-		{0,  0,  0,     1}
-	};
-	*/
 	Eigen::Matrix4d transformTip = transform7;
 	Eigen::Vector3d localAxisTip(0, 0, 0);
 	Eigen::Vector3d spatialAxisTip = transformTip.block(0, 0, 3, 3) * localAxisTip;

--- a/src/Kinematics.cpp
+++ b/src/Kinematics.cpp
@@ -1,7 +1,6 @@
 #include "Kinematics.h"
 #include "DualQuaternion.h"
 #include <Eigen/Dense>
-#include <iostream>
 
 namespace Kinematics
 {

--- a/src/LCPSolve.cpp
+++ b/src/LCPSolve.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <cmath>
 #include <Eigen/Dense>
 #include "LCPSolve.h"

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -7,7 +7,6 @@
 #include <Eigen/Dense>
 #include <vector>
 #include <map>
-#include <iostream>
 
 // Constructor.
 MotionPlanner::MotionPlanner(SpatialManipulator* pSpatialManipulator, const Eigen::Matrix4d& goalTransform)
@@ -58,15 +57,7 @@ Eigen::VectorXd MotionPlanner::getCollisionDisplacementChange(const Eigen::Vecto
             const ContactPoint& contactPoint = body.getContactPoint();
             if (contactPoint.m_isActive)
             {
-                contactPoints.insert({ bodyIndex, contactPoint });
-                
-                //std::cout << "Body Index: " << bodyIndex << "\n";
-                //std::cout << "Distance: " << contactPoint.m_distance << "\n";
-                //std::cout << "Point: " << contactPoint.m_point.transpose() << "\n";
-                //std::cout << "Normal: " << contactPoint.m_normal.transpose() << "\n";
-                //std::cout << "Spatial Jacobian: \n" << body.getSpatialJacobian() << "\n";
-                //std::cout << "Contact Jacobian: \n" << body.getContactJacobian() << "\n";
-                
+                contactPoints.insert({ bodyIndex, contactPoint });            
             }
         }
         bodyIndex++;
@@ -158,8 +149,6 @@ void MotionPlanner::computePlan()
 
 		// Formulate and solve LCP to get the compensating velocities and compute joint displacement change.
         Eigen::VectorXd collisionDisplacementChange = getCollisionDisplacementChange(displacementChange);
-        //std::cout << "Iter " << iter << ": " << collisionDisplacementChange.transpose() << "\n";
-        //Eigen::VectorXd collisionDisplacementChange = Eigen::VectorXd::Zero(m_dof);
 
         // Add joint displacements and ensure they respect the linearization assumption.
         Eigen::VectorXd totalDisplacementChange = getTotalDisplacementChange(displacementChange, collisionDisplacementChange);
@@ -192,6 +181,4 @@ void MotionPlanner::computePlan()
 
 		iter++;
 	}
-
-
 }

--- a/src/PhysXEnv.cpp
+++ b/src/PhysXEnv.cpp
@@ -26,9 +26,11 @@ void PhysXEnv::init()
 	m_foundation = PxCreateFoundation(PX_PHYSICS_VERSION, m_allocator, m_errorCallback);
 
 	// Initialize PVD.
+	#ifndef NDEBUG
 	m_pvd = physx::PxCreatePvd(*m_foundation);
 	physx::PxPvdTransport* transport = physx::PxDefaultPvdSocketTransportCreate("127.0.0.1", 5425, 10);
 	m_pvd->connect(*transport, physx::PxPvdInstrumentationFlag::eALL);
+	#endif
 
 	// Create physics factory class.
 	m_toleranceScale.length = 0.1f;

--- a/src/PhysXEnv.cpp
+++ b/src/PhysXEnv.cpp
@@ -11,8 +11,6 @@
 #include "SpatialManipulator.h"
 #include "RigidBodyChain.h"
 #include "CollisionAggregate.h"
-#include <iostream>
-
 
 // Default constructor.
 PhysXEnv::PhysXEnv()

--- a/src/RigidBody.cpp
+++ b/src/RigidBody.cpp
@@ -6,7 +6,6 @@
 #include "Box.h"
 #include <vector>
 #include "Kinematics.h"
-#include <iostream>
 
 // Constructor.
 RigidBody::RigidBody(const Joint& joint, const Eigen::Matrix4d& referenceSpatialTransform)

--- a/src/RigidBodyChain.cpp
+++ b/src/RigidBodyChain.cpp
@@ -4,7 +4,6 @@
 #include "Kinematics.h"
 #include <vector>
 #include <Eigen/Dense>
-#include <iostream>
 
 // Default constructor.
 RigidBodyChain::RigidBodyChain()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,8 +82,8 @@ void testMotionPlan()
 	// Pure translation.
 	if (plan == 0)
 	{
-		goalTransform1.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, -0.35, 0.5);
-		goalTransform2.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, 0.35, 0.5);
+		goalTransform1.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, -0.35, 0.4);
+		goalTransform2.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, 0.35, 0.4);
 	}
 
 	// Pure rotation.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,9 +76,30 @@ void testMotionPlan()
 
 	// Setup goal poses.
 	Eigen::Matrix4d goalTransform1(startTransform);
-	goalTransform1.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, -0.35, 0.5);
 	Eigen::Matrix4d goalTransform2(startTransform);
-	goalTransform2.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, 0.35, 0.5);
+	const int plan = 0;
+
+	// Pure translation.
+	if (plan == 0)
+	{
+		goalTransform1.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, -0.35, 0.5);
+		goalTransform2.block(0, 3, 3, 1) = Eigen::Vector3d(0.65, 0.35, 0.5);
+	}
+
+	// Pure rotation.
+	if (plan == 1)
+	{
+		goalTransform1.block(0, 0, 3, 3) = Eigen::Matrix3d{
+			{1, 0, 0},
+			{0, 1, 0},
+			{0, 0, 1}
+		};
+		goalTransform2.block(0, 0, 3, 3) = Eigen::Matrix3d{
+			{1, 0,  0},
+			{0, 0, -1},
+			{0, 1,  0}
+		};
+	}
 
 	// Generate motion plan.
 	auto start = std::chrono::steady_clock::now();
@@ -94,7 +115,7 @@ void testMotionPlan()
 	std::cout << "Goal Transform 2: \n" << goalTransform2 << "\n\n";
 	std::cout << "Acheived Transform 2: \n" << achievedTransform2 << "\n\n";
 
-	// Elapsed time. ~0.125 ms/iteration, or 8000 hz.
+	// Elapsed time.
 	auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count();
 	std::cout << "Elapsed Time: " << elapsedTime << " ms" << std::endl;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,25 +6,9 @@
 #include "Sphere.h"
 #include "Capsule.h"
 #include "Box.h"
-#include "CollisionAggregate.h"
 
-#include "Joint.h"
-#include "RigidBody.h"
-#include "RigidBodyChain.h"
-#include "SpatialManipulator.h"
 #include "FrankaPanda.h"
-#include "PhysXEnv.h"
-#include "Kinematics.h"
-#include "MotionPlanner.h"
 
-void testTransform();
-void testTransInv();
-void testLCPSolve();
-void testEigenSpeed();
-void testDualNumber();
-void testDualQuaternion();
-void testGeometry();
-void testPandaSimulation();
 void testMotionPlan();
 
 int main()
@@ -35,200 +19,10 @@ int main()
 	// Reset seed.
 	srand(time(NULL));
 
-	//testTransform();
-	//testTransInv();
-	//testLCPSolve();
-	//testEigenSpeed();
-	//testDualNumber();
-	//testDualQuaternion();
-	//testGeometry();
-	//testPandaSimulation();
+	// Test planner.
 	testMotionPlan();
+
 	return 0;
-}
-
-void testTransform()
-{
-	// Create robot.
-	Eigen::Matrix4d pandaBaseTransform{
-		{1, 0, 0, 1},
-		{0, 1, 0, 1},
-		{0, 0, 1, 0},
-		{0, 0, 0, 1}
-	};
-
-	// Create point in world frame.
-	Eigen::Vector4d pointWorld{2, 2, 2, 1};
-
-	// Transform point to spatial frame.
-	Eigen::Vector4d pointSpatial = Kinematics::transformInverse(pandaBaseTransform) * pointWorld;
-	std::cout << pointSpatial << std::endl;
-}
-
-void testTransInv()
-{
-	Eigen::Vector3d axis = {0.3152, 0.752, 0.126};
-	double angle = 1.572;
-	Eigen::Vector3d translation = {0.3352, 0.5472, 0.562};
-
-	axis.normalize();
-	Eigen::Matrix3d R = Kinematics::AxisAngletoRot(axis, angle);
-
-	Eigen::Matrix4d T = Eigen::Matrix4d::Identity();
-	T.block(0, 0, 3, 3) = R;
-	T.block(0, 3, 3, 1) = translation;
-
-	std::cout << "Transform: \n" << T << std::endl;
-	std::cout << "Matrix Inverse: \n" << T.inverse() << std::endl;
-	std::cout << "Fast Inverse: \n" << Kinematics::transformInverse(T) << std::endl;
-}
-
-void testLCPSolve()
-{
-	// Init.
-	size_t nContacts = 10;
-	Eigen::MatrixXd M = Eigen::MatrixXd::Random(nContacts, nContacts);
-	Eigen::VectorXd q = Eigen::VectorXd::Random(nContacts);
-
-	// Code.
-	auto start = std::chrono::steady_clock::now();
-	for (size_t i = 0; i < 1000; i++)
-	{
-		//LCP sol = LCPSolve(M, q);
-	}
-	auto stop = std::chrono::steady_clock::now();
-
-	// Elapsed time.
-	auto elapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(stop - start).count();
-	std::cout << "Elapsed Time: " << elapsedTime << " us" << std::endl;
-}
-
-void testEigenSpeed()
-{
-	// Init.
-	Eigen::Matrix4d mat1{
-		{0.3425, 0.23561, 0.12461, 0.2152},
-		{0.26536, 0.3462, -0.323461, -0.243612},
-		{0.12365, -0.2357641, 0.001, 3.2351},
-		{0, 0, 0, 1}
-	};
-	Eigen::Matrix4d mat2{
-		{0.57425, 0.5561, 0.22461, 0.7552},
-		{0.83536, -0.3462, 0.4623461, -0.8612},
-		{0.78365, -0.97641, 0.174, 1.7351},
-		{0, 0, 0, 1}
-	};
-
-	// Code to be tested.
-	size_t numIter = 100;
-	auto start = std::chrono::steady_clock::now();
-	for (size_t i = 0; i < numIter; i++)
-	{
-		Eigen::Matrix4d matProd = mat1 * mat2;
-	}
-	auto stop = std::chrono::steady_clock::now();
-
-	// Elapsed time.
-	auto elapsedTime = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
-	std::cout << "Elapsed Time: " << elapsedTime << " ns" << std::endl;
-}
-
-void testDualNumber()
-{
-
-}
-
-void testDualQuaternion()
-{
-
-}
-
-void testGeometry()
-{
-	// Sphere.
-	Eigen::Vector3d sphereOrigin(0, 0, 0);
-	Eigen::Vector3d sphereRPY(0, 0, 0);
-	double sphereRadius = 0.2;
-	Sphere sphere(sphereOrigin, sphereRPY, sphereRadius, "sphere");
-
-	// Capsule.
-	Eigen::Vector3d capsuleOrigin(5, 0, 0);
-	Eigen::Vector3d capsuleRPY(0, 0, 0);
-	double capsuleHalfHeight = 0.2;
-	double capsuleRadius = 0.1;
-	Capsule capsule(capsuleOrigin, capsuleRPY, capsuleHalfHeight, capsuleRadius, "capsule");
-
-	// Box.
-	Eigen::Vector3d boxOrigin(10, 0, 0);
-	Eigen::Vector3d boxRPY(0, 0, 0);
-	Eigen::Vector3d boxRadii(0.3, 0.3, 0.3);
-	Box box(boxOrigin, boxRPY, boxRadii, "box");
-
-	// Collision aggregate.
-	CollisionAggregate collisionAggregate;
-	collisionAggregate.addShape(sphere);
-	collisionAggregate.addShape(capsule);
-	collisionAggregate.addShape(box);
-
-	// Get shapes in aggregate.
-	std::vector<Sphere> spheres = collisionAggregate.getSpheres();
-	std::vector<Capsule> capsules = collisionAggregate.getCapsules();
-	std::vector<Box> boxes = collisionAggregate.getBoxes();
-
-	// Get transforms of the shapes.
-	Eigen::Matrix4d sphereTrans = spheres[0].getTransform();
-	Eigen::Matrix4d capsuleTrans = capsules[0].getTransform();
-	Eigen::Matrix4d boxTrans = boxes[0].getTransform();
-
-	std::cout << sphereTrans << std::endl;
-	std::cout << capsuleTrans << std::endl;
-	std::cout << boxTrans << std::endl;
-}
-
-void testPandaSimulation()
-{
-	// Create robot.
-	Eigen::Matrix4d pandaBaseTransform{
-		{1, 0, 0, 1},
-		{0, 1, 0, 1},
-		{0, 0, 1, 0},
-		{0, 0, 0, 1}
-	};
-	FrankaPanda panda(pandaBaseTransform);
-
-	// Add obstacles.
-	Sphere sphereObstacle(Eigen::Vector3d(1.0, 1.25, 0.65), Eigen::Vector3d(0, 0, 0), 0.1, "sphereObstacle");
-	Sphere sphereObstacle2(Eigen::Vector3d(1.25, 1.0, 0.45), Eigen::Vector3d(0, 0, 0), 0.1, "sphereObstacle2");
-	panda.addObstacle(sphereObstacle);
-	panda.addObstacle(sphereObstacle2);
-
-	// Update joint angles.
-	double pi = 3.1415;
-	double increment = 0.005 * pi/2;
-	Eigen::VectorXd jointAngles = Eigen::Vector<double, 7>::Zero();
-	panda.setJointDisplacements(jointAngles);
-
-	std::vector<double> jointAnglesGoal(7, pi/2);
-	jointAnglesGoal[3] = -pi / 2;
-	auto start = std::chrono::steady_clock::now();
-	for (size_t i = 0; i < 1000; i++)
-	{
-		double t = i / 1000.0;
-		Eigen::VectorXd jointAnglesInterp = Eigen::Vector<double, 7>::Zero();
-		for (size_t i = 0; i < jointAngles.size(); i++)
-		{
-			jointAnglesInterp[i] = (1 - t) * jointAngles[i] + t * jointAnglesGoal[i];
-		}
-		panda.setJointDisplacements(jointAnglesInterp);
-	}
-	auto stop = std::chrono::steady_clock::now();
-
-	// Elapsed time.
-	auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count();
-	std::cout << "Elapsed Time: " << elapsedTime << " ms" << std::endl;
-
-	// Currently seeing ~13 ms / 1000 iterations with linear interpolation & 2 sphere obstacles.
-	// ~14-15 ms with 2 box obstacles.
 }
 
 void testMotionPlan()
@@ -300,49 +94,7 @@ void testMotionPlan()
 	std::cout << "Goal Transform 2: \n" << goalTransform2 << "\n\n";
 	std::cout << "Acheived Transform 2: \n" << achievedTransform2 << "\n\n";
 
-	// Elapsed time.
+	// Elapsed time. ~0.125 ms/iteration, or 8000 hz.
 	auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count();
 	std::cout << "Elapsed Time: " << elapsedTime << " ms" << std::endl;
-
-	// ~0.125 ms/iteration, or 8000 hz.
-	
 }
-
-
-
-
-
-// ----------
-// Next Steps:
-//  + Transformation matrix inverse.
-//  + Conversion jacobian.
-//  + Contact jacobian.
-//  + Motion Planner
-// 
-// Refactoring: Once planner is working as expected.
-//	- B Matrix.
-//  - Dynamic polymorphism for Shapes.
-//  - Review structure and program flow.
-//  - Optimize LCP solver.
-//  - Link safety distance.
-//  - Return EndFrame (and others) by reference, not copy.
-//  - Sparse multiplication with zero-padded jacobians.
-//  - Check if initial config is within range of goal to avoid divide by zero/nan issues.
-//	- Eigen AxisAngle(Quaternion) wrong? Representation singularity.
-//  - Pow of DualQuat needs fixing and optimization.
-//  - Investigate why orientation is correct until EE is close to goal position, then goes wild.
-//  - Review dual quaternion power and cleanup.
-//  - Last box doesn't have collision?
-//  - Contact points switch between links and obstacles... how to make consistant?
-// 
-//----------
-
-
-
-//---------
-// ScLERP Issue: Not interpolating correctly.
-//	- Will either not generate configs between values, or will flip them.
-// 
-// Ideas:
-//	- Storage direction of scalar -> vec or vec -> scalar in Eigen::Quaternion is causing issues with our kinematics.
-//---------


### PR DESCRIPTION
- Added individual control over max displacement thresholds for ScLERP, collision resolution, and overall step. This greatly reduces motion plan computation time and improves stability by treating each linearization-sensitive component as separate.
- Added document "docs/issues.md" to track bugs, optimizations, and new features.
- Adjusted convergence to evaluate rotation and position separately.
- Removed PVD setup from release builds, as this was taking ~30 ms. PhysXEnv and SpatialManipulator construction now takes <1 ms, down from ~30 ms.